### PR TITLE
Shortcut for amending a commit without message

### DIFF
--- a/scripts/bashrc
+++ b/scripts/bashrc
@@ -40,6 +40,10 @@ _git_psh ()
 {
     _git_push
 }
+_git_amend ()
+{
+	_git_commit_--amend_--no-edit
+}
 
 # git alias land
 complete -o default -F _git g
@@ -70,6 +74,8 @@ g ()
 			eval git push $@;;
 		s)
 			eval git status $@;;
+		amend)
+			eval git commit --amend --no-edit;;
 		*)
 			eval git $arg1 $@;;
 	esac

--- a/scripts/win-bashrc
+++ b/scripts/win-bashrc
@@ -35,6 +35,10 @@ _git_psh ()
 {
     _git_push
 }
+_git_amend ()
+{
+	_git_commit_--amend_--no-edit
+}
 g()
 {
 	arg1=$1
@@ -62,6 +66,8 @@ g()
 			eval git push $@;;
 		s)
 			eval git status $@;;
+		amend)
+			eval git commit --amend --no-edit;;
 		*)
 			eval git $arg1 $@;;
 	esac


### PR DESCRIPTION
The added shortcut was taken from [this stackoverflow thread](https://stackoverflow.com/questions/10237071/how-to-amend-a-commit-without-changing-commit-message-reusing-the-previous-one) which is a slightly more advanced command allowing users to amend a commit without editing the message. 